### PR TITLE
Make sure we don't over run buffer

### DIFF
--- a/src/emulation.c
+++ b/src/emulation.c
@@ -59,7 +59,7 @@ static void mpu_clear_carry(void) {
 }
 
 static void mpu_dump(void) {
-    char buffer[64];
+    char buffer[124];
     M6502_dump(mpu, buffer);
     fprintf(stderr, "6502 state: %s\n", buffer);
 }


### PR DESCRIPTION
gcc 12 spotted that buffer was only declared with 64 bytes but in lib6502.h M6502dump declares the buffer will have 124 bytes. This will probably never over run in the real world, but removes gcc 12 build error