### PR TITLE
Add very basic support for MSVC.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ src/*.o
 test/out/*.out
 test/tmp/zz-test-*.bas
 basictool
+/basictool.exe
+/basictool.pdb
+/basictool.ilk
+/src/*.obj
+/src/bintoinc.exe

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ $ TARGETCC=x86_64-w64-mingw32-gcc make
 
 If you're not on a Unix-like system you may need to create your own build script or project file for your IDE. src/Makefile may be a good starting point; alternatively there is a simple shell script src/make.sh which will perform a build and it may be easiest for you to translate that into your platform's equivalent of a shell script. If you do this, please consider sending me the results so I can add them and make it easier for other people to build on your platform.
 
+On Windows, to build with the Visual Studio compiler, you should be able to run src/make.bat from a native tools command prompt.
+
 ## Getting help
 
 If you have problems or suggestions for improvement, you can raise an issue or submit a pull request in github. Alternatively you may like to post in the [basictool thread](https://stardot.org.uk/forums/viewtopic.php?f=55&t=22210&p=315577#p315577) on the [stardot](https://stardot.org.uk) forums.

--- a/src/driver.c
+++ b/src/driver.c
@@ -406,7 +406,7 @@ static void type_basic_program(char *data, size_t length) {
         }
 
         // Generate the fake input for BASIC and pass it over.
-        const int buffer_size = 256;
+        enum {buffer_size = 256};
         char buffer[buffer_size];
         check(snprintf(buffer, buffer_size, "%d%s", basic_line_number, line) <
               buffer_size, "error: line too long");

--- a/src/make.bat
+++ b/src/make.bat
@@ -1,0 +1,17 @@
+@REM Build basictool with Visual C++
+
+cl /std:c11 /Fe:bintoinc.exe bintoinc.c
+bintoinc ../roms/EDITORA100 > zz-editor-a.c
+@IF ERRORLEVEL 1 EXIT /B 1
+
+bintoinc ../roms/EDITORB100 > zz-editor-b.c
+@IF ERRORLEVEL 1 EXIT /B 1
+
+bintoinc ../roms/Basic2 > zz-basic-2.c
+@IF ERRORLEVEL 1 EXIT /B 1
+
+bintoinc ../roms/Basic432 > zz-basic-4.c
+@IF ERRORLEVEL 1 EXIT /B 1
+
+cl /MT /Zi /O2 /D_CRT_DECLARE_NONSTDC_NAMES=0 /std:c11 /Fd:../basictool.pdb /Fe:../basictool.exe main.c config.c emulation.c driver.c roms.c utils.c lib6502.c cargs.c
+@IF ERRORLEVEL 1 EXIT /B 1


### PR DESCRIPTION
One code change required: turn `const int` into `enum`, so it's a compile-time constant. Otherwise, just a question of cobbling together a quick batch file and updating `.gitignore`.

You might not want to merge this as it stands, as the basictool tests (which I ran using Git Bash) mostly fail - I assume because they use output redirection, rather than `--output-binary` and an explicit output file. So I need to have a go at fixing this - if that sounds like the right thing to do? But I thought I'd submit a PR anyway, as advance warning that this is something I'm doing.

The binary does pass my own tests, comparing basictool's output with BBCBasicToText.py.